### PR TITLE
fix: fix error in ci relating to missing db host and db port variables

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,8 +7,6 @@ class Settings(BaseSettings):
     postgres_db: str
     postgres_user: str
     postgres_password: str
-    db_host: str
-    db_port: str
     
     class Config:
         env_file = ".env"


### PR DESCRIPTION
### What does this PR do?
- Fixes error in ci relating to missing `db_host` and `db_port` variables